### PR TITLE
feat: Add clipboard-based settings import/export

### DIFF
--- a/lib/generated/oss_licenses.dart
+++ b/lib/generated/oss_licenses.dart
@@ -40,6 +40,7 @@ const allDependencies = <Package>[
   _favicon,
   _ffi,
   _file,
+  _file_picker,
   _fixnum,
   _flutter,
   _flutter_code_editor,
@@ -53,6 +54,7 @@ const allDependencies = <Package>[
   _flutter_markdown_plus,
   _flutter_math_fork,
   _flutter_oss_licenses,
+  _flutter_plugin_android_lifecycle,
   _flutter_svg,
   _flutter_web_plugins,
   _google_fonts,
@@ -181,6 +183,7 @@ const dependencies = <Package>[
   _webview_flutter,
   _favicon,
   _share_plus,
+  _file_picker,
   _open_file,
   _intl,
   _animations,
@@ -2534,6 +2537,41 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.''',
     devDependencies: [PackageRef('lints')],
   );
 
+/// file_picker 8.3.7
+const _file_picker = Package(
+    name: 'file_picker',
+    description: 'A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extension filtering support.',
+    homepage: 'https://github.com/miguelpruivo/plugins_flutter_file_picker',
+    repository: 'https://github.com/miguelpruivo/flutter_file_picker',
+    authors: [],
+    version: '8.3.7',
+    license: '''MIT License
+
+Copyright (c) 2018 Miguel Ruivo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.''',
+    isMarkdown: false,
+    isSdk: false,
+    dependencies: [PackageRef('flutter'), PackageRef('flutter_web_plugins'), PackageRef('flutter_plugin_android_lifecycle'), PackageRef('plugin_platform_interface'), PackageRef('ffi'), PackageRef('path'), PackageRef('win32'), PackageRef('cross_file'), PackageRef('web')],
+    devDependencies: [PackageRef('lints')],
+  );
+
 /// fixnum 1.1.1
 const _fixnum = Package(
     name: 'fixnum',
@@ -3399,6 +3437,44 @@ SOFTWARE.''',
     isSdk: false,
     dependencies: [PackageRef('dart_pubspec_licenses')],
     devDependencies: [PackageRef('flutter_lints')],
+  );
+
+/// flutter_plugin_android_lifecycle 2.0.30
+const _flutter_plugin_android_lifecycle = Package(
+    name: 'flutter_plugin_android_lifecycle',
+    description: 'Flutter plugin for accessing an Android Lifecycle within other plugins.',
+    repository: 'https://github.com/flutter/packages/tree/main/packages/flutter_plugin_android_lifecycle',
+    authors: [],
+    version: '2.0.30',
+    license: '''Copyright 2013 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.''',
+    isMarkdown: false,
+    isSdk: false,
+    dependencies: [PackageRef('flutter')],
+    devDependencies: [],
   );
 
 /// flutter_svg 2.2.1
@@ -8303,7 +8379,7 @@ Public License instead of this License.  But first, please read
 <https://www.gnu.org/licenses/why-not-lgpl.html>.''',
     isMarkdown: false,
     isSdk: false,
-    dependencies: [PackageRef('flutter'), PackageRef('package_info_plus'), PackageRef('device_info_plus'), PackageRef('path_provider'), PackageRef('pub_semver'), PackageRef('url_launcher'), PackageRef('permission_handler'), PackageRef('archive'), PackageRef('crypto'), PackageRef('cupertino_icons'), PackageRef('dynamic_color'), PackageRef('google_fonts'), PackageRef('flutter_svg'), PackageRef('flutter_local_notifications'), PackageRef('timezone'), PackageRef('http'), PackageRef('html'), PackageRef('flutter_markdown_plus'), PackageRef('flutter_code_editor'), PackageRef('code_text_field'), PackageRef('highlight'), PackageRef('flutter_highlight'), PackageRef('shared_preferences'), PackageRef('provider'), PackageRef('webview_flutter'), PackageRef('favicon'), PackageRef('share_plus'), PackageRef('open_file'), PackageRef('intl'), PackageRef('animations'), PackageRef('yaml'), PackageRef('flutter_math_fork')],
+    dependencies: [PackageRef('flutter'), PackageRef('package_info_plus'), PackageRef('device_info_plus'), PackageRef('path_provider'), PackageRef('pub_semver'), PackageRef('url_launcher'), PackageRef('permission_handler'), PackageRef('archive'), PackageRef('crypto'), PackageRef('cupertino_icons'), PackageRef('dynamic_color'), PackageRef('google_fonts'), PackageRef('flutter_svg'), PackageRef('flutter_local_notifications'), PackageRef('timezone'), PackageRef('http'), PackageRef('html'), PackageRef('flutter_markdown_plus'), PackageRef('flutter_code_editor'), PackageRef('code_text_field'), PackageRef('highlight'), PackageRef('flutter_highlight'), PackageRef('shared_preferences'), PackageRef('provider'), PackageRef('webview_flutter'), PackageRef('favicon'), PackageRef('share_plus'), PackageRef('file_picker'), PackageRef('open_file'), PackageRef('intl'), PackageRef('animations'), PackageRef('yaml'), PackageRef('flutter_math_fork')],
     devDependencies: [PackageRef('flutter_launcher_icons'), PackageRef('flutter_lints'), PackageRef('change_app_package_name'), PackageRef('flutter_oss_licenses')],
   );
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -11,6 +11,7 @@ import '../providers/theme_provider.dart';
 import '../services/about_info.dart'; // Import AboutInfo
 import '../services/auto_update_manager.dart'; // Import auto update manager
 import '../services/enhanced_update_service.dart'; // Use enhanced service
+import '../services/settings_service.dart';
 import '../utils/app_fonts.dart'; // Import app fonts helper
 import '../utils/text_style_helper.dart';
 import '../widgets/shared/custom_sliver_app_bar.dart'; // Import CustomSliverAppBar
@@ -578,13 +579,44 @@ class _SettingsScreenState extends State<SettingsScreen> {
       children: [
         ListTile(
           title: Text(
-            '設定をエクスポート',
+            '設定をクリップボードにコピー',
             style: AppFonts.notoSansJp(
               fontSize: 16,
               fontWeight: FontWeight.w400,
             ),
           ),
-          subtitle: const Text('現在の設定をファイルに保存'),
+          subtitle: const Text('現在の設定をクリップボードにコピーします'),
+          leading: const Icon(Icons.copy_all_outlined),
+          onTap: () async {
+            HapticFeedback.lightImpact();
+            await _exportSettingsToClipboard();
+          },
+        ),
+        ListTile(
+          title: Text(
+            'クリップボードから設定をインポート',
+            style: AppFonts.notoSansJp(
+              fontSize: 16,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
+          subtitle: const Text('クリップボードから設定を復元します'),
+          leading: const Icon(Icons.paste_outlined),
+          onTap: () async {
+            HapticFeedback.lightImpact();
+            await _importSettingsFromClipboard();
+          },
+        ),
+        const Divider(),
+        ListTile(
+          title: Text(
+            '設定をファイルにエクスポート',
+            style: AppFonts.notoSansJp(
+              fontSize: 16,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
+          subtitle: const Text('現在の設定をファイルに保存/共有'),
           leading: const Icon(Icons.upload_file),
           onTap: () async {
             HapticFeedback.lightImpact();
@@ -593,7 +625,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
         ListTile(
           title: Text(
-            '設定をインポート',
+            'ファイルから設定をインポート',
             style: AppFonts.notoSansJp(
               fontSize: 16,
               fontWeight: FontWeight.w400,
@@ -860,31 +892,23 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   // エクスポート/インポートメソッド群
   Future<void> _exportSettings() async {
-    try {
-      // ここで SharedPreferences や ThemeProvider を用いて設定を収集し、
-      // 今後ファイルへ書き出す処理を実装予定。
-      // 将来的にファイルとして保存する実装を追加
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('設定のエクスポート機能は開発中です')));
-    } catch (e) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('設定のエクスポートに失敗しました: $e')));
-    }
+    final settingsService = SettingsService(context);
+    await settingsService.exportSettings();
   }
 
   Future<void> _importSettings() async {
-    try {
-      // 将来的にファイルから設定を読み込む実装を追加
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('設定のインポート機能は開発中です')));
-    } catch (e) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('設定のインポートに失敗しました: $e')));
-    }
+    final settingsService = SettingsService(context);
+    await settingsService.importSettings();
+  }
+
+  Future<void> _exportSettingsToClipboard() async {
+    final settingsService = SettingsService(context);
+    await settingsService.exportSettingsToClipboard();
+  }
+
+  Future<void> _importSettingsFromClipboard() async {
+    final settingsService = SettingsService(context);
+    await settingsService.importSettingsFromClipboard();
   }
 
   Future<void> _exportTemplates() async {

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsService {
+  final BuildContext context;
+
+  SettingsService(this.context);
+
+  Future<void> exportSettings() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final allSettings = <String, dynamic>{};
+
+      // Get all keys and filter them if necessary
+      final keys = prefs.getKeys();
+      for (String key in keys) {
+        allSettings[key] = prefs.get(key);
+      }
+
+      final jsonString = json.encode(allSettings);
+      final directory = await getTemporaryDirectory();
+      final file = File('${directory.path}/shojin_settings.json');
+      await file.writeAsString(jsonString);
+
+      await Share.shareXFiles([XFile(file.path)], text: 'Shojin App Settings');
+      _showSnackBar('Settings exported successfully.');
+    } catch (e) {
+      _showSnackBar('Failed to export settings: $e', isError: true);
+    }
+  }
+
+  Future<void> importSettings() async {
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+      );
+
+      if (result != null) {
+        final file = File(result.files.single.path!);
+        final jsonString = await file.readAsString();
+        final settings = json.decode(jsonString) as Map<String, dynamic>;
+
+        final prefs = await SharedPreferences.getInstance();
+        for (var key in settings.keys) {
+          final value = settings[key];
+          if (value is bool) {
+            await prefs.setBool(key, value);
+          } else if (value is int) {
+            await prefs.setInt(key, value);
+          } else if (value is double) {
+            await prefs.setDouble(key, value);
+          } else if (value is String) {
+            await prefs.setString(key, value);
+          } else if (value is List<String>) {
+            await prefs.setStringList(key, value);
+          }
+        }
+        _showSnackBar('Settings imported successfully.');
+      } else {
+        _showSnackBar('File selection cancelled.');
+      }
+    } catch (e) {
+      _showSnackBar('Failed to import settings: $e', isError: true);
+    }
+  }
+
+  void _showSnackBar(String message, {bool isError = false}) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError ? Colors.red : Colors.green,
+      ),
+    );
+  }
+
+  Future<void> exportSettingsToClipboard() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final allSettings = <String, dynamic>{};
+
+      final keys = prefs.getKeys();
+      for (String key in keys) {
+        allSettings[key] = prefs.get(key);
+      }
+
+      final jsonString = json.encode(allSettings);
+      await Clipboard.setData(ClipboardData(text: jsonString));
+
+      _showSnackBar('Settings copied to clipboard.');
+    } catch (e) {
+      _showSnackBar('Failed to copy settings: $e', isError: true);
+    }
+  }
+
+  Future<void> importSettingsFromClipboard() async {
+    try {
+      final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+      if (clipboardData == null || clipboardData.text == null) {
+        _showSnackBar('Clipboard is empty.');
+        return;
+      }
+
+      final settings = json.decode(clipboardData.text!) as Map<String, dynamic>;
+      final prefs = await SharedPreferences.getInstance();
+
+      for (var key in settings.keys) {
+        final value = settings[key];
+        if (value is bool) {
+          await prefs.setBool(key, value);
+        } else if (value is int) {
+          await prefs.setInt(key, value);
+        } else if (value is double) {
+          await prefs.setDouble(key, value);
+        } else if (value is String) {
+          await prefs.setString(key, value);
+        } else if (value is List<String>) {
+          await prefs.setStringList(key, value);
+        }
+      }
+
+      _showSnackBar('Settings imported from clipboard.');
+    } catch (e) {
+      _showSnackBar('Failed to import from clipboard: $e', isError: true);
+    }
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import device_info_plus
 import dynamic_color
+import file_picker
 import flutter_local_notifications
 import open_file_mac
 import package_info_plus
@@ -19,6 +20,7 @@ import webview_flutter_wkwebview
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.7"
   fixnum:
     dependency: transitive
     description:
@@ -331,6 +339,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.11"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: b0694b7fb1689b0e6cc193b3f1fcac6423c4f93c74fb20b806c6b6f196db0c31
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.30"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   webview_flutter: ^4.7.0
   favicon: ^1.1.0
   share_plus: ^12.0.0
+  file_picker: ^8.0.6
   open_file: ^3.5.10
   intl: ^0.20.2
   animations: ^2.0.11


### PR DESCRIPTION
このコミットは、クリップボードベースの機能を追加することにより、設定のインポート/エクスポート機能を強化します。

`SettingsService` は、2つの新しいメソッドで更新されました：
- `exportSettingsToClipboard`: 設定をJSON文字列にシリアライズし、クリップボードにコピーします。
- `importSettingsFromClipboard`: クリップボードからJSON文字列を読み取り、デシリアライズして設定を保存します。

`SettingsScreen`（設定画面）は、これらのクリップボード操作のための新しいUIオプションを含むように変更され、適切なアイコンとラベルが追加されました。 既存のファイルベースのインポート/エクスポートオプションは、明確にするためにラベルが変更されました。